### PR TITLE
README: also requires intltool to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ used by applications such as Unity and Plank.
 
 ### Build Requirements
  - gir1.2-gtk-3.0
+ - intltool
  - libgnome-menu-3-dev
  - python-gi-dev
  - python3


### PR DESCRIPTION
Current README does not specify intltool as one of the build requirements, resulting in build failure in environments where this package is not installed.