### PR TITLE
Change homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ used by applications such as Unity and Plank.
     sudo python3 setup.py install
 
 ## Links
- - [Homepage](https://github.com/bluesabre/menulibre)
+ - [Homepage](https://bluesabre.org/menulibre/)
  - [Releases](https://github.com/bluesabre/menulibre/releases)
  - [Bug Reports](https://github.com/bluesabre/menulibre/issues)
  - [Translations](https://www.transifex.com/bluesabreorg/menulibre)


### PR DESCRIPTION
For some reason, the homepage was linking to the GitHub repository and not to https://bluesabre.org/menulibre/