### PR TITLE
enable save launcher when editing Name and Comment

### DIFF
--- a/menulibre/MenulibreApplication.py
+++ b/menulibre/MenulibreApplication.py
@@ -246,7 +246,7 @@ class MenulibreWindow(Gtk.ApplicationWindow):
         # Set up the application editor
         self.configure_application_editor(builder)
 
-        # Set up the applicaton browser
+        # Set up the application browser
         self.configure_application_treeview(builder)
 
         # Determining paths of bad desktop files GMenu can't load - if some are
@@ -712,6 +712,19 @@ class MenulibreWindow(Gtk.ApplicationWindow):
                            self.on_NameCommentIcon_focus_in_event)
             button.connect('focus-out-event',
                            self.on_NameCommentIcon_focus_out_event)
+
+        for widget_name in ['Name', 'Comment']:
+            entry = builder.get_object('entry_%s' % widget_name)
+
+            # Commit changes to entries when focusing out.
+            entry.connect('focus-out-event',
+                          self.on_entry_focus_out_event,
+                          widget_name)
+
+            # Enable saving on any edit with an Entry.
+            entry.connect("changed",
+                          self.on_entry_changed,
+                          widget_name)
 
         for widget_name in ['Exec', 'Path', 'GenericName', 'TryExec',
                             'OnlyShowIn', 'NotShowIn', 'MimeType', 'Keywords',

--- a/po/menulibre.pot
+++ b/po/menulibre.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-15 07:20-0400\n"
+"POT-Creation-Date: 2020-12-05 16:39-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -124,7 +124,7 @@ msgstr ""
 
 #. Translators: Placeholder text/hint for the application comment entry.
 #. Translators: "Description" tree column header
-#: ../data/ui/MenulibreWindow.ui.h:37 ../menulibre/MenulibreApplication.py:832
+#: ../data/ui/MenulibreWindow.ui.h:37 ../menulibre/MenulibreApplication.py:845
 msgid "Description"
 msgstr ""
 
@@ -544,8 +544,8 @@ msgid "Click on the main application window for '%s'."
 msgstr ""
 
 #. Translators: Separator menu item
-#: ../menulibre/MenuEditor.py:91 ../menulibre/MenulibreApplication.py:1213
-#: ../menulibre/MenulibreApplication.py:1711
+#: ../menulibre/MenuEditor.py:91 ../menulibre/MenulibreApplication.py:1226
+#: ../menulibre/MenulibreApplication.py:1724
 msgid "Separator"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 
 #. Translators: Quit action tooltip
 #: ../menulibre/MenulibreApplication.py:473
-#: ../menulibre/MenulibreApplication.py:2241
+#: ../menulibre/MenulibreApplication.py:2254
 msgid "Quit"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 
 #. Translators: Help action tooltip
 #: ../menulibre/MenulibreApplication.py:482
-#: ../menulibre/MenulibreApplication.py:2239
+#: ../menulibre/MenulibreApplication.py:2252
 msgid "Help"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 
 #. Translators: About action tooltip
 #: ../menulibre/MenulibreApplication.py:491
-#: ../menulibre/MenulibreApplication.py:2240
+#: ../menulibre/MenulibreApplication.py:2253
 msgid "About"
 msgstr ""
 
@@ -808,84 +808,84 @@ msgid "Advanced"
 msgstr ""
 
 #. Translators: Launcher-specific categories, camelcase "This Entry"
-#: ../menulibre/MenulibreApplication.py:800
+#: ../menulibre/MenulibreApplication.py:813
 msgid "ThisEntry"
 msgstr ""
 
 #. Translators: Placeholder text for the launcher-specific category
 #. selection.
-#: ../menulibre/MenulibreApplication.py:821
+#: ../menulibre/MenulibreApplication.py:834
 msgid "Select a category"
 msgstr ""
 
 #. Translators: "Category Name" tree column header
-#: ../menulibre/MenulibreApplication.py:825
+#: ../menulibre/MenulibreApplication.py:838
 msgid "Category Name"
 msgstr ""
 
 #. Translators: "This Entry" launcher-specific category group
-#: ../menulibre/MenulibreApplication.py:928
+#: ../menulibre/MenulibreApplication.py:941
 msgid "This Entry"
 msgstr ""
 
 #. Translators: Placeholder text for a newly created action
-#: ../menulibre/MenulibreApplication.py:989
+#: ../menulibre/MenulibreApplication.py:1002
 msgid "New Shortcut"
 msgstr ""
 
 #. Translators: File Chooser Dialog, window title.
-#: ../menulibre/MenulibreApplication.py:1139
+#: ../menulibre/MenulibreApplication.py:1152
 msgid "Select a working directory…"
 msgstr ""
 
 #. Translators: File Chooser Dialog, window title.
-#: ../menulibre/MenulibreApplication.py:1143
+#: ../menulibre/MenulibreApplication.py:1156
 msgid "Select an executable…"
 msgstr ""
 
 #. Translators: This error is displayed when the user does not
 #. have sufficient file system permissions to delete the
 #. selected file.
-#: ../menulibre/MenulibreApplication.py:1389
+#: ../menulibre/MenulibreApplication.py:1402
 msgid "You do not have permission to delete this file."
 msgstr ""
 
 #. Translators: Placeholder text for a newly created launcher.
-#: ../menulibre/MenulibreApplication.py:1637
+#: ../menulibre/MenulibreApplication.py:1650
 msgid "New Launcher"
 msgstr ""
 
 #. Translators: Placeholder text for a newly created launcher's
 #. description.
-#: ../menulibre/MenulibreApplication.py:1640 ../menulibre/MenulibreXdg.py:49
+#: ../menulibre/MenulibreApplication.py:1653 ../menulibre/MenulibreXdg.py:49
 msgid "A small descriptive blurb about this application."
 msgstr ""
 
 #. Translators: Placeholder text for a newly created directory.
-#: ../menulibre/MenulibreApplication.py:1690
+#: ../menulibre/MenulibreApplication.py:1703
 msgid "New Directory"
 msgstr ""
 
 #. Translators: Placeholder text for a newly created directory's
 #. description.
-#: ../menulibre/MenulibreApplication.py:1693
+#: ../menulibre/MenulibreApplication.py:1706
 msgid "A small descriptive blurb about this directory."
 msgstr ""
 
 #. Translators: Confirmation dialog to delete the selected
 #. separator.
-#: ../menulibre/MenulibreApplication.py:2118
+#: ../menulibre/MenulibreApplication.py:2131
 msgid "Are you sure you want to delete this separator?"
 msgstr ""
 
 #. Translators: Confirmation dialog to delete the selected launcher.
-#: ../menulibre/MenulibreApplication.py:2122
+#: ../menulibre/MenulibreApplication.py:2135
 #, python-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr ""
 
 #. Translators: Menu item to open the Parsing Errors dialog.
-#: ../menulibre/MenulibreApplication.py:2234
+#: ../menulibre/MenulibreApplication.py:2247
 msgid "Parsing Error Log"
 msgstr ""
 


### PR DESCRIPTION
fixes #57 

trigger `on_entry_focus_out_event` and `on_entry_changed` for `entry_Name` and `entry_Comment`