### PR TITLE
Without the require it fails to build (arch)

### DIFF
--- a/menulibre/MenulibreApplication.py
+++ b/menulibre/MenulibreApplication.py
@@ -26,6 +26,8 @@ import tempfile
 
 from locale import gettext as _
 
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gio, GLib, GObject, Gtk, Gdk, GdkPixbuf
 
 from . import MenulibreStackSwitcher, MenulibreIconSelection


### PR DESCRIPTION
Don't know why `setup.py` tries to run the application module, but I can say that without specifying the gtk version of course it can't be imported in this point in time.