### PR TITLE
Add developer name and OARS rating

### DIFF
--- a/data/metainfo/menulibre.appdata.xml.in
+++ b/data/metainfo/menulibre.appdata.xml.in
@@ -6,6 +6,7 @@
   <project_license>GPL-3.0+</project_license>
   <name>MenuLibre</name>
   <_summary>An advanced FreeDesktop.org compliant menu editor</_summary>
+  <content_rating type="oars-1.0"/>
 
   <description>
     <_p>

--- a/data/metainfo/menulibre.appdata.xml.in
+++ b/data/metainfo/menulibre.appdata.xml.in
@@ -7,6 +7,7 @@
   <name>MenuLibre</name>
   <_summary>An advanced FreeDesktop.org compliant menu editor</_summary>
   <content_rating type="oars-1.0"/>
+  <developer_name>Bluesabre</developer_name>
 
   <description>
     <_p>


### PR DESCRIPTION
The current metadata file is lacking for Flathub:
```
❯ flatpak run org.freedesktop.appstream-glib validate data/metainfo/menulibre.appdata.xml.in
data/metainfo/menulibre.appdata.xml.in: FAILED:
• tag-missing           : <content_rating> required [use https://odrs.gnome.org/oars]
Validation of files failed
```

This MR fixes this issue by giving it an OARS rating, thus making it sufficient:

```
❯ flatpak run org.freedesktop.appstream-glib validate data/metainfo/menulibre.appdata.xml.in 
data/metainfo/menulibre.appdata.xml.in: OK
```

This MR additionally adds a developer name.

Related: https://github.com/bluesabre/menulibre/issues/65, https://github.com/flathub/flathub/pull/2608.