### PR TITLE
setup.py: fix install failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -248,6 +248,7 @@ DistUtilsExtra.auto.setup(
     license='GPL-3',
     author='Sean Davis',
     author_email='sean@bluesabre.org',
+    requires='',
     description='advanced menu editor with support for Unity actions',
     long_description='An advanced menu editor that provides modern features '
                      'and full Unity action support. Suitable for lightweight '


### PR DESCRIPTION
Use pip 25.3 to install failed
```
Traceback (most recent call last):
  File "menulibre-2.4.0/setup.py", line 245, in <module>
    DistUtilsExtra.auto.setup(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        name='menulibre',
        ^^^^^^^^^^^^^^^^^
    ...<12 lines>...
        cmdclass={'install': InstallAndUpdateDataDirectory}
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "recipe-sysroot-native/usr/lib/python3.13/site-packages/DistUtilsExtra/auto.py", line 98, in setup
    __requires(attrs, src_all)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "recipe-sysroot-native/usr/lib/python3.13/site-packages/DistUtilsExtra/auto.py", line 471, in __requires
    __add_imports(imports, s, attrs)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "recipe-sysroot-native/usr/lib/python3.13/site-packages/DistUtilsExtra/auto.py", line 405, in __add_imports
    if alias.name and __external_mod(cur_module, alias.name, attrs):
                      ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "recipe-sysroot-native/usr/lib/python3.13/site-packages/DistUtilsExtra/auto.py", line 377, in __external_mod
    return 'dist-packages' in mod.__file__ or 'site-packages' in mod.__file__ or \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable ...
```
Refer [1] to correct one line in setup.py

[1] https://github.com/epoptes/epoptes/commit/81be63961a428728601df6f442490638df3bd263